### PR TITLE
Regex constant fix

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,1 @@
-//TODO: fix word delimiter regex
-//currently the word delimiter regex is not completely correct, if
-//there is a comma followed by a space it counts the space as a word
-//which is wrong behavior, also it should clear words from things
-//like (dots, question and exclamation marks.. etc)
-export const WORD_DECIMETER = /[\b\s(?:,| )+]/;
+export const WORD_DECIMETER = /[\b\s ()?!:,|\[\]+.-;"^'`´&-]+/;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,1 @@
-export const WORD_DECIMETER = /[\b\s ()?!:,|\[\]+.-;"^'`´&-]+/;
+export const WORD_DECIMETER = /[^\b\s ()?!:,|\[\]+.-;"^'`´&-]+/g;

--- a/src/getWordCount.test.js
+++ b/src/getWordCount.test.js
@@ -18,15 +18,15 @@ describe( 'getWordCount', () => {
   } );
 
   it( 'should split words correctly', () => {
-    let mockedMessages = [ 'Message, , '];
-    let expectedResult = { "_message": 1 };
+    let mockedMessages = [ 'Message()?!:,|[]+.-;\"^\'`´&- ', 'Message,  ,. Message. + . - Message?'];
+    let expectedResult = { "_message": 4 }
 
     let result = getWordsCount( mockedMessages );
     expect( result ).toEqual( expectedResult );
 
   } );
 
-  it( 'should return count of all messages', () => {
+  it( 'should return count of all words', () => {
     let mockedMessages = [ 'first message', 'second message here', 'and the last one' ];
     let expectedResult = {
       '_first'  : 1,
@@ -43,5 +43,6 @@ describe( 'getWordCount', () => {
     expect( result ).toEqual( expectedResult );
 
   } );
+
 
 } );

--- a/src/getWordCount.test.js
+++ b/src/getWordCount.test.js
@@ -19,7 +19,7 @@ describe( 'getWordCount', () => {
 
   it( 'should split words correctly', () => {
     let mockedMessages = [ 'Message, , '];
-    let expectedResult = {"_": 3, "_message": 1};
+    let expectedResult = { "_message": 1 };
 
     let result = getWordsCount( mockedMessages );
     expect( result ).toEqual( expectedResult );

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -2,5 +2,5 @@ import { WORD_DECIMETER } from '../constants';
 
 export const messageToArrayOfWords = ( message ) => {
   // the filter discards the empty strings that might get returned by split()
-  return message.trim().split( WORD_DECIMETER ).filter(Boolean);
+  return message.trim().match( WORD_DECIMETER );
 };

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -1,5 +1,6 @@
 import { WORD_DECIMETER } from '../constants';
 
 export const messageToArrayOfWords = ( message ) => {
-  return message.trim().split( WORD_DECIMETER );
+  // the filter discards the empty strings that might get returned by split()
+  return message.trim().split( WORD_DECIMETER ).filter(Boolean);
 };

--- a/src/utils/message.test.js
+++ b/src/utils/message.test.js
@@ -26,7 +26,7 @@ describe( 'utils>message', () => {
   it( 'should skip commas', () => {
 
     let message       = 'Two hundred euros,I think,is sufficient.';
-    let expectedArray = [ "Two", "hundred", "euros", "I", "think", "is", "sufficient." ];
+    let expectedArray = [ "Two", "hundred", "euros", "I", "think", "is", "sufficient" ];
     let result        = messageToArrayOfWords( message );
 
     expect( result ).toEqual( expectedArray );


### PR DESCRIPTION
Fixed the regex and changed the split() function
- [x] removes non word symbols
- [x] does not return an empty string